### PR TITLE
Fixing Mavericks problem where data dir can't be found.

### DIFF
--- a/quacker/settings.cpp
+++ b/quacker/settings.cpp
@@ -53,7 +53,7 @@ Settings::Settings(QWidget *parent)
 {
 	QDir appDir = QDir(QCoreApplication::applicationDirPath());
 	// Make up for the idiosyncracies of Mac OSX bundle paths.
-	#ifdef Q_WS_MAC
+	#ifdef Q_OS_MAC
 	appDir.cdUp();
 	appDir.cdUp();
 	appDir.cdUp();


### PR DESCRIPTION
This should fix issue #1  -- but please check with Windows and older versions of Mac OS X - I am unable to.
