### PR TITLE
Port quackle to Qt 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 language: cpp
+dist: trusty
 compiler:
   - gcc
   - clang
-install:
-- if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 addons:
   apt:
-    sources:
-    - ubuntu-toolchain-r-test
     packages:
-    - gcc-4.8
-    - g++-4.8
+    - gcc
+    - g++
     - clang
     - qtbase5-dev
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
     - g++
     - clang
     - qtbase5-dev
+    - qt5-qmake
 script: 
   - qmake -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC" && make
   - cd quackleio && qmake -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC" && make

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     - gcc-4.8
     - g++-4.8
     - clang
-    - libqt4-dev
+    - qtbase5-dev
 script: 
   - qmake -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC" && make
   - cd quackleio && qmake -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC" && make

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ dist: trusty
 compiler:
   - gcc
   - clang
+install:
+  - export QT_SELECT=5
 addons:
   apt:
     packages:
@@ -11,7 +13,7 @@ addons:
     - clang
     - qtbase5-dev
     - qt5-qmake
-script: 
+script:
   - qmake -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC" && make
   - cd quackleio && qmake -r "QMAKE_CXX=$CXX" "QMAKE_CC=$CC" && make
   - cd ..

--- a/README.MacOS
+++ b/README.MacOS
@@ -2,9 +2,9 @@ Requirements:
 -------------
 
 1. Xcode (for the compiler and build tools)
-2. A version of Qt 4.  I use HomeBrew to grab the latest version,
-   presently Qt 4.8.6. Installing in HomeBrew is as easy as
-		brew install qt
+2. A version of Qt 5.  I use HomeBrew to grab the latest version,
+   presently Qt 5.5.1. Installing in HomeBrew is as easy as
+		brew install qt5
 
 Building Quackle:
 -----------------

--- a/README.Windows
+++ b/README.Windows
@@ -5,8 +5,8 @@ Quackle was first ported to Windows by John Fultz, jfultz@wolfram.com, who
 is also the original author of this ReadMe.
 
 I maintain the Windows version so that it can be built with either
-Visual C++ or the GNU-based MinGW compiler.  As of Quackle 0.97,
-I use the mingw tools bundled with Qt 4.7.4 to build the release version.
+Visual C++ or the GNU-based MinGW compiler.  As of Quackle 1.0.1,
+I use the mingw tools bundled with Qt 5.4 to build the release version.
 The build ought to work with Visual C++ Express, as well, but I'm not
 sure whether Microsoft disables useful optimizations in that version,
 so I won't guarantee that you'll get nice and fast optimized binaries.
@@ -17,14 +17,14 @@ tools are:
 Free Tools Build:
 ------------------------------------
 MinGW
-Qt 4.8
+Qt 5.4
 git
 cygwin (optional) - if you want to debug, you'll need gdb from cygwin.
 
 Microsoft Tools Build:
 ------------------------------------
 Visual C++
-Qt 4.8
+Qt 5.4
 git
 
 Installer build:
@@ -70,7 +70,7 @@ working executable...
 Additional things to know:
 --------------------------
 * To build the Quackle installer,
-  + Copy QtCore4.dll and QtGui4.dll from Qt's bin/ directory into quackle\
+  + Copy QtCore5.dll and QtGui5.dll from Qt's bin/ directory into quackle\
   + If you're building with MinGW, copy mingwm10.dll, libstdc++-6.dll, and
     libgcc_s_dw2-1.dll from MinGW's bin/ directory into quackle\
   + From the Quackle directory, run the following...
@@ -115,4 +115,4 @@ Building Qt libraries
   configure process.
 
   Here's a helpful document on the process:
-  https://qt-project.org/doc/qt-4.8/install-win.html
+  https://doc.qt.io/qt-5/windows-support.html#downloading-and-installing-qt

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See LICENSE in this directory.
 
 Building Quackle:
 -----------------
-Quackle is built and tested with the latest release of Qt 4.8.  It does not presently build against Qt 5.
+Quackle is built and tested with the latest release of Qt 5.5.
 See README.MacOS and README.Windows for platform-specific instructions.  Generally:
 
 Clone the repo or download the tarball and untar.  Use qmake to build quackle.pro and quackleio/quackleio.pro:

--- a/quacker/bagdisplay.cpp
+++ b/quacker/bagdisplay.cpp
@@ -19,6 +19,10 @@
 #include <math.h>
 
 #include <QtGui>
+#include <QTextEdit>
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QScrollBar>
 
 #include <bag.h>
 #include <game.h>

--- a/quacker/boarddisplay.cpp
+++ b/quacker/boarddisplay.cpp
@@ -17,6 +17,13 @@
  */
 
 #include <QtGui>
+#include <QTextEdit>
+#include <QLineEdit>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QLabel>
+#include <QMessageBox>
 
 #include <alphabetparameters.h>
 #include <board.h>

--- a/quacker/boardsetup.cpp
+++ b/quacker/boardsetup.cpp
@@ -20,6 +20,8 @@
 #include <math.h>
 
 #include <QtGui>
+#include <QVBoxLayout>
+#include <QLabel>
 
 #include <game.h>
 #include <move.h>

--- a/quacker/boardsetupdialog.cpp
+++ b/quacker/boardsetupdialog.cpp
@@ -18,6 +18,16 @@
 
 #include <sstream>
 #include <QtGui>
+#include <QCheckBox>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QComboBox>
+#include <QMessageBox>
+#include <QLineEdit>
+
 #include <boardparameters.h>
 #include <board.h>
 #include <datamanager.h>

--- a/quacker/brb.cpp
+++ b/quacker/brb.cpp
@@ -17,6 +17,8 @@
  */
 
 #include <QtGui>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
 
 #include <game.h>
 

--- a/quacker/configdialog.cpp
+++ b/quacker/configdialog.cpp
@@ -17,6 +17,12 @@
  */
 
 #include <QtGui>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QListWidget>
+#include <QStackedWidget>
+#include <QCheckBox>
+#include <QPushButton>
 
 #include "configpages.h"
 #include "configdialog.h"

--- a/quacker/configpages.cpp
+++ b/quacker/configpages.cpp
@@ -17,6 +17,13 @@
  */
 
 #include <QtGui>
+#include <QCheckBox>
+#include <QGroupBox>
+#include <QSpinBox>
+#include <QComboBox>
+#include <QLabel>
+#include <QGridLayout>
+#include <QVBoxLayout>
 
 #include <uv.h>
 

--- a/quacker/dashboard.cpp
+++ b/quacker/dashboard.cpp
@@ -17,6 +17,9 @@
  */
 
 #include <QtGui>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
 
 #include <game.h>
 #include <quackleio/util.h>

--- a/quacker/geometry.cpp
+++ b/quacker/geometry.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <QtGui>
+#include <QBoxLayout>
 
 #include "geometry.h"
 

--- a/quacker/graphicalboard.cpp
+++ b/quacker/graphicalboard.cpp
@@ -20,6 +20,8 @@
 #include <math.h>
 
 #include <QtGui>
+#include <QVBoxLayout>
+#include <qdrawutil.h>
 
 #include <game.h>
 #include <move.h>

--- a/quacker/graphicalreporter.cpp
+++ b/quacker/graphicalreporter.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <QtGui>
+#include <QMessageBox>
 
 #include <board.h>
 #include <computerplayer.h>

--- a/quacker/history.cpp
+++ b/quacker/history.cpp
@@ -17,6 +17,9 @@
  */
 
 #include <QtGui>
+#include <QVBoxLayout>
+#include <QTableWidget>
+#include <QTableWidgetItem>
 
 #include <game.h>
 #include <quackleio/util.h>

--- a/quacker/letterbox.cpp
+++ b/quacker/letterbox.cpp
@@ -17,6 +17,15 @@
  */
 
 #include <QtGui>
+#include <QStatusBar>
+#include <QAction>
+#include <QMessageBox>
+#include <QVBoxLayout>
+#include <QLineEdit>
+#include <QMenu>
+#include <QMenuBar>
+#include <QFileDialog>
+#include <QInputDialog>
 
 #include <quackleio/dictfactory.h>
 #include <quackleio/util.h>
@@ -305,7 +314,7 @@ void Letterbox::jumpTo()
 	pause(true);
 
 	bool ok;
-	int index = QInputDialog::getInteger(this, tr("Jump to word - Quackle Letterbox"), tr("Index to which to jump:"), m_numberIterator + 1, 1, m_clueResults.count(), 1, &ok);
+	int index = QInputDialog::getInt(this, tr("Jump to word - Quackle Letterbox"), tr("Index to which to jump:"), m_numberIterator + 1, 1, m_clueResults.count(), 1, &ok);
 	if (ok)
 	{
 		jumpTo(index);

--- a/quacker/lexicondialog.cpp
+++ b/quacker/lexicondialog.cpp
@@ -18,6 +18,15 @@
 
 #include <sstream>
 #include <QtGui>
+#include <QLineEdit>
+#include <QComboBox>
+#include <QPushButton>
+#include <QFileDialog>
+#include <QLabel>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QGroupBox>
+
 #include <datamanager.h>
 #include <quackleio/util.h>
 

--- a/quacker/lister.cpp
+++ b/quacker/lister.cpp
@@ -20,6 +20,15 @@
 using namespace std;
 
 #include <QtGui>
+#include <QSpinBox>
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QLineEdit>
+#include <QCheckBox>
+#include <QListWidget>
+#include <QPushButton>
+#include <QFileDialog>
+#include <QMessageBox>
 
 #include <quackleio/dictfactory.h>
 

--- a/quacker/movebox.cpp
+++ b/quacker/movebox.cpp
@@ -19,6 +19,11 @@
 #include <iostream>
 
 #include <QtGui>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
 
 #include <game.h>
 #include <quackleio/util.h>

--- a/quacker/newgame.cpp
+++ b/quacker/newgame.cpp
@@ -19,6 +19,14 @@
 #include <iostream>
 
 #include <QtGui>
+#include <QTabWidget>
+#include <QTreeWidget>
+#include <QPushButton>
+#include <QComboBox>
+#include <QGroupBox>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLineEdit>
 
 #include <computerplayer.h>
 #include <datamanager.h>

--- a/quacker/noteeditor.cpp
+++ b/quacker/noteeditor.cpp
@@ -17,6 +17,8 @@
  */
 
 #include <QtGui>
+#include <QVBoxLayout>
+#include <QTextEdit>
 
 #include <game.h>
 #include <quackleio/util.h>

--- a/quacker/oppothreadprogressbar.cpp
+++ b/quacker/oppothreadprogressbar.cpp
@@ -17,6 +17,9 @@
  */
 
 #include <QtGui>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QHBoxLayout>
 
 #include "geometry.h"
 #include "oppothreadprogressbar.h"

--- a/quacker/quacker.cpp
+++ b/quacker/quacker.cpp
@@ -22,6 +22,23 @@
 using namespace std;
 
 #include <QtGui>
+#include <QApplication>
+#include <QMessageBox>
+#include <QInputDialog>
+#include <QStatusBar>
+#include <QAction>
+#include <QFileDialog>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QGroupBox>
+#include <QMenuBar>
+#include <QToolBar>
+#include <QMenu>
+#include <QSplitter>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
 
 #include <game.h>
 #include <boardparameters.h>

--- a/quacker/quacker.pro
+++ b/quacker/quacker.pro
@@ -3,6 +3,7 @@ VERSION = 1.0.1
 TARGET = Quackle
 DEPENDPATH += .. ../quackleio
 INCLUDEPATH += . ..
+QT += widgets core gui
 
 MOC_DIR = moc
 
@@ -32,7 +33,7 @@ win32:!win32-g++ {
 macx:LIBS += -framework CoreFoundation
 
 QMAKE_CXXFLAGS += -std=c++11
-QMAKE_CXXFLAGS:!win32-msvc2013 += -Wno-unknown-warning-option -Wno-deprecated-register
+#QMAKE_CXXFLAGS:!win32-msvc2013 += -Wno-unknown-warning-option -Wno-deprecated-register
 
 # Input
 HEADERS += *.h

--- a/quacker/rackdisplay.cpp
+++ b/quacker/rackdisplay.cpp
@@ -19,6 +19,10 @@
 #include <iostream>
 
 #include <QtGui>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QLabel>
 
 #include <game.h>
 #include <quackleio/util.h>

--- a/quacker/settings.cpp
+++ b/quacker/settings.cpp
@@ -22,7 +22,12 @@
 #include <sstream>
 
 #include <QtGui>
+#include <QGridLayout>
+#include <QComboBox>
 #include <QMessageBox>
+#include <QLabel>
+#include <QPushButton>
+#include <QStandardPaths>
 
 #ifdef Q_WS_MAC
 #include <CoreFoundation/CoreFoundation.h>
@@ -92,7 +97,7 @@ Settings::Settings(QWidget *parent)
 			QMessageBox::critical(0, tr("Error Initializing Data Files - Quacker"), tr("<p>Could not open data directory. Quackle will be useless. Try running the quacker executable with quackle/quacker/ as the current directory.</p>"));
 		m_appDataDir = directory.absolutePath();
 	}
-	m_userDataDir = QDesktopServices::storageLocation(QDesktopServices::DataLocation);
+	m_userDataDir = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
 	QDir qdir(m_userDataDir);
 	qdir.mkpath("lexica");
 }

--- a/quacker/simviewer.cpp
+++ b/quacker/simviewer.cpp
@@ -19,6 +19,12 @@
 #include <iostream>
 
 #include <QtGui>
+#include <QTabWidget>
+#include <QPushButton>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QTextEdit>
+#include <QMessageBox>
 
 #include <quackleio/util.h>
 

--- a/quackleio/froggetopt.cpp
+++ b/quackleio/froggetopt.cpp
@@ -180,6 +180,12 @@ GetOpt::GetOpt( int argc, char *argv[] )
 
 void GetOpt::init( const QStringList &argv, int offset )
 {
+    numReqArgs = numOptArgs = 0;
+    currArg = 1; // appname is not part of the arguments
+
+    // application name
+    aname = QFileInfo( argv[0] ).fileName();
+
     for ( int i = offset; i < argv.size(); ++i )
         args.append( argv[i] );
 }

--- a/quackleio/froggetopt.cpp
+++ b/quackleio/froggetopt.cpp
@@ -130,7 +130,7 @@ GetOpt::GetOpt()
 	if ( !QCoreApplication::instance() )
 		qFatal( "GetOpt: requires a QApplication instance to be constructed first" );
 
-	init( QCoreApplication::instance()->argc(), QCoreApplication::instance()->argv(), 1 );
+	init( QCoreApplication::instance()->arguments(), 1 );
 }
 
 /**
@@ -141,7 +141,7 @@ GetOpt::GetOpt( int offset )
 	if ( !QCoreApplication::instance() )
 		qFatal( "GetOpt: requires a QApplication instance to be constructed first" );
 
-	init( QCoreApplication::instance()->argc(), QCoreApplication::instance()->argv(), offset );
+	init( QCoreApplication::instance()->arguments(), offset );
 }
 
 /**
@@ -176,6 +176,12 @@ GetOpt::GetOpt( int argc, char *argv[] )
 : args( a )
 {
 	init( 0, 0 );
+}
+
+void GetOpt::init( const QStringList &argv, int offset )
+{
+    for ( int i = offset; i < argv.size(); ++i )
+        args.append( argv[i] );
 }
 
 /**

--- a/quackleio/froggetopt.h
+++ b/quackleio/froggetopt.h
@@ -103,6 +103,7 @@ private:
     QMap<QString, int> setOptions;
 
     void init( int argc, char *argv[], int offset = 1 );
+    void init( const QStringList &argv, int offset = 1 );
     void addOption( Option o );
     void setSwitch( const Option &o );
 

--- a/quackleio/quackleio.pro
+++ b/quackleio/quackleio.pro
@@ -21,7 +21,7 @@ CONFIG += release staticlib
 CONFIG -= x11
 
 QMAKE_CXXFLAGS += -std=c++11
-QMAKE_CXXFLAGS:!win32-msvc2013 += -Wno-unknown-warning-option -Wno-deprecated-register
+#QMAKE_CXXFLAGS:!win32-msvc2013 += -Wno-unknown-warning-option -Wno-deprecated-register
 
 # Input
 HEADERS += *.h

--- a/quackleio/util.cpp
+++ b/quackleio/util.cpp
@@ -138,12 +138,12 @@ QString Util::letterToQString(const Quackle::Letter &letter)
 
 string Util::qstringToStdString(const QString &qstring)
 {
-	return string(qstring.toAscii());
+	return string(qstring.toLatin1());
 }
 
 QString Util::stdStringToQString(const string &stdString)
 {
-	return QString::fromAscii(stdString.c_str());
+	return QString::fromLatin1(stdString.c_str());
 }
 
 Quackle::LetterString Util::alphagram(const Quackle::LetterString &word) 


### PR DESCRIPTION
This PR ports quackle to Qt 5.5. Here are some important points about the update: 
- It is only tested on Linux.
- One significant change is the location of the data directory, it is now in `$HOME/.local/share/Quackle.org` instead of old `$HOME/.local/share/data/Quackle.org` which requires users to regenerate `gaddag` files.
- One thing I couldn't figure out is `QMAKE_CXXFLAGS:!win32-msvc2013` expressions in `.pro` file. I commented them out for now since qmake 5 does not accept this syntax. We can change it to:

```
win32-msvc2013 {
QMAKE_CXXFLAGS += ...
}
```

but I couldn't make sure if this is the correct fix.
