### PR TITLE
Make UTF-8 the default encoding (and write pragma)

### DIFF
--- a/quackleio/gcgio.cpp
+++ b/quackleio/gcgio.cpp
@@ -329,7 +329,8 @@ bool GCGIO::canRead(QTextStream &stream) const
 void GCGIO::write(const Quackle::Game &game, QTextStream &stream)
 {
 	Quackle::PlayerList players = game.players();
-	stream.setCodec(QTextCodec::codecForName("ISO-8859-1"));
+    stream.setCodec(QTextCodec::codecForName("UTF-8"));
+    stream << "#character-encoding UTF-8" << endl;
 	for (Quackle::PlayerList::iterator it = players.begin(); it != players.end(); ++it)
 	{
 		stream << "#player" << (*it).id() + 1 << " " << Util::uvStringToQString((*it).abbreviatedName()) << " " << Util::uvStringToQString((*it).name()) << endl;

--- a/quackleio/iotest/capp.gcg
+++ b/quackleio/iotest/capp.gcg
@@ -1,3 +1,4 @@
+#character-encoding UTF-8
 #player1 Brian Brian Cappelletto
 #player2 Pakorn Pakorn Nemitrmansuk
 #title WSC 2001 Round 20: Brian Cappelletto vs. Pakorn Nemitrmansuk


### PR DESCRIPTION
See #58 for a previous PR on the same issue (had to delete it because I accidentally merged another local branch into it).

When reading, leave ISO-8859-1 as the default, and only change stream encoding if #character-encoding present. When writing, set encoding to UTF-8 and write #character-encoding pragma at the top of the .gcg file.

@jfultz, do you think this is acceptable for both English and international users?