### PR TITLE
fix for passing an argument to setGlobalCandidate

### DIFF
--- a/quacker/graphicalboard.cpp
+++ b/quacker/graphicalboard.cpp
@@ -745,7 +745,7 @@ void GraphicalBoardFrame::deleteHandler()
 
 void GraphicalBoardFrame::submitHandler()
 {
-    QTimer::singleShot(0, this, SLOT(setGlobalCandidate(nullptr)));
+    QTimer::singleShot(0, this, [this] {setGlobalCandidate(nullptr);} );
 }
 
 void GraphicalBoardFrame::commitHandler()


### PR DESCRIPTION
Fixes the following error on hitting enter:
```
QMetaObject::invokeMethod: No such method GraphicalBoardFrame::setGlobalCandidate()
Candidates are:
    setGlobalCandidate(bool*)
```