### PR TITLE
Don't generate bindings that require copying a logStream.

### DIFF
--- a/bindings/quackle.i
+++ b/bindings/quackle.i
@@ -1,3 +1,7 @@
+%rename("$ignore") Quackle::SimmedMoveMessageQueue::pop;
+%rename("$ignore") Quackle::SimmedMoveMessageQueue::pop_or_terminate;
+%rename("$ignore") logStream;
+
 %module quackle
 %{
 #include "fixedstring.h"


### PR DESCRIPTION
swig has a problem with non-copyable objects being moved in and out of
containers; we can bypass the problem with SimmedMoveMessage by simply
not generating bindings for the relevant methods.