### PR TITLE
Allow larger word lists to be compiled as GADDAGs

### DIFF
--- a/makegaddag/makegaddag.cpp
+++ b/makegaddag/makegaddag.cpp
@@ -98,6 +98,9 @@ int main(int argc, char **argv)
 	UVcout << "Generating nodes...";
 	factory.generate();
 
+	UVcout << "Deduplicating tails...";
+	factory.dedupTails();
+
 	UVcout << "Writing index...";
 	factory.writeIndex(outputFilename.toUtf8().constData());
 

--- a/quacker/settings.cpp
+++ b/quacker/settings.cpp
@@ -261,6 +261,7 @@ void Settings::buildGaddag()
 	pushIndex(factory, word, 1, wordCount);
 	setGaddagLabel(QString(tr("Lexicon total: %1 words.  Compressing...")).arg(wordCount));
 	factory.generate();
+	factory.dedupTails();
 	setGaddagLabel(QString(tr("Lexicon total: %1 words.  Writing to disk...")).arg(wordCount));
 	if (factory.writeIndex(gaddagFile)) {
 		QUACKLE_LEXICON_PARAMETERS->loadGaddag(gaddagFile);

--- a/quacker/settings.cpp
+++ b/quacker/settings.cpp
@@ -259,17 +259,15 @@ void Settings::buildGaddag()
 
 	setGaddagLabel(tr("Words processed: 0"));
 	pushIndex(factory, word, 1, wordCount);
-	if (wordCount < QUACKLE_MAX_GADDAG_WORDCOUNT)
-	{
-		setGaddagLabel(QString(tr("Lexicon total: %1 words.  Compressing...")).arg(wordCount));
-		factory.generate();
-		setGaddagLabel(QString(tr("Lexicon total: %1 words.  Writing to disk...")).arg(wordCount));
-		factory.writeIndex(gaddagFile);
+	setGaddagLabel(QString(tr("Lexicon total: %1 words.  Compressing...")).arg(wordCount));
+	factory.generate();
+	setGaddagLabel(QString(tr("Lexicon total: %1 words.  Writing to disk...")).arg(wordCount));
+	if (factory.writeIndex(gaddagFile)) {
 		QUACKLE_LEXICON_PARAMETERS->loadGaddag(gaddagFile);
 		setGaddagLabel();
-	}
-	else
+	} else {
 		setGaddagLabel(tr("Your lexicon is too large to be represented using the internal database format.  Operation aborted."));
+	}
 }
 
 void Settings::pushIndex(GaddagFactory &factory, Quackle::LetterString &word, int index, int &wordCount)
@@ -291,14 +289,10 @@ void Settings::pushIndex(GaddagFactory &factory, Quackle::LetterString &word, in
 			wordCount++;
 			if (wordCount % 1000 == 0)
 				setGaddagLabel(QString(tr("Words processed: %1")).arg(wordCount));
-			if (wordCount > QUACKLE_MAX_GADDAG_WORDCOUNT)
-				return;
 		}
 		if (p)
 		{
 			pushIndex(factory, word, p, wordCount);
-			if (wordCount > QUACKLE_MAX_GADDAG_WORDCOUNT)
-				return;
 		}
 		index++;
 		word.pop_back();

--- a/quackleio/gaddagfactory.cpp
+++ b/quackleio/gaddagfactory.cpp
@@ -113,13 +113,14 @@ bool GaddagFactory::writeIndex(const string &fname)
 {
 	m_nodelist.push_back(&m_root);
 
-	m_root.print(m_nodelist);    
-
+	// Store all the nodes, in a breadth-first fashion (this minimizes
+	// the offset sizes). Note that m_nodelist.size() grows all the time.
 	for (unsigned int i = 0; i < m_nodelist.size(); i++) {
+		m_nodelist[i]->print(m_nodelist);
+
 		unsigned int p = (unsigned int)(m_nodelist[i]->pointer);
 		if (p != 0 && p - i > 0xFFFFFF) {
 			// Will not fit in our 24-byte offset field, so will give you garbage words.
-			// The OSPS dictionary is known to trigger such overflows.
 			return false;
 		}
 	}
@@ -168,9 +169,6 @@ void GaddagFactory::Node::print(vector< Node* >& nodelist)
 
 	for (size_t i = 0; i < children.size(); i++)
 		nodelist.push_back(&children[i]);
-
-	for (size_t i = 0; i < children.size(); i++)
-		children[i].print(nodelist);
 }
 
 

--- a/quackleio/gaddagfactory.cpp
+++ b/quackleio/gaddagfactory.cpp
@@ -109,11 +109,20 @@ void GaddagFactory::generate()
 	//		m_root.pushWord(words);
 }
 
-void GaddagFactory::writeIndex(const string &fname)
+bool GaddagFactory::writeIndex(const string &fname)
 {
 	m_nodelist.push_back(&m_root);
 
 	m_root.print(m_nodelist);    
+
+	for (unsigned int i = 0; i < m_nodelist.size(); i++) {
+		unsigned int p = (unsigned int)(m_nodelist[i]->pointer);
+		if (p != 0 && p - i > 0xFFFFFF) {
+			// Will not fit in our 24-byte offset field, so will give you garbage words.
+			// The OSPS dictionary is known to trigger such overflows.
+			return false;
+		}
+	}
 
 	ofstream out(fname.c_str(), ios::out | ios::binary);
 
@@ -145,6 +154,7 @@ void GaddagFactory::writeIndex(const string &fname)
 		bytes[0] = n1; bytes[1] = n2; bytes[2] = n3; bytes[3] = n4;
 		out.write(bytes, 4);
 	}
+	return true;
 }
 
 

--- a/quackleio/gaddagfactory.h
+++ b/quackleio/gaddagfactory.h
@@ -22,11 +22,6 @@
 #include <cstdint>
 #include "flexiblealphabet.h"
 
-// This isn't a strict maximum...you can go higher...but too much higher, and you risk overflowing
-// node pointers, which will get you garbage words.  The OSPS dictionary is known to trigger
-// such overflows.
-const int QUACKLE_MAX_GADDAG_WORDCOUNT = 500000;
-
 class GaddagFactory {
 public:
 
@@ -45,7 +40,7 @@ public:
 	void hashWord(const Quackle::LetterString &word);
 	void sortWords() { sort(m_gaddagizedWords.begin(), m_gaddagizedWords.end()); };
 	void generate();
-	void writeIndex(const string &fname);
+	bool writeIndex(const string &fname);
 
 	const char* hashBytes() { return m_hash.charptr; };
 

--- a/quackleio/gaddagfactory.h
+++ b/quackleio/gaddagfactory.h
@@ -40,6 +40,7 @@ public:
 	void hashWord(const Quackle::LetterString &word);
 	void sortWords() { sort(m_gaddagizedWords.begin(), m_gaddagizedWords.end()); };
 	void generate();
+	void dedupTails();
 	bool writeIndex(const string &fname);
 
 	const char* hashBytes() { return m_hash.charptr; };
@@ -56,6 +57,8 @@ private:
 			void pushWord(const Quackle::LetterString& word);
 			void print(vector< Node* >& m_nodelist);
 	};
+	static void createDedupKey(const Node *n, char *bytes);
+	size_t dedupTailsOnePass();
 
 	int m_encodableWords;
 	int m_unencodableWords;


### PR DESCRIPTION
Hi,

DAWG usage seems fairly slow (e.g. dawgAt() is a very hot function, but it's virtual in order to support two different formats), so having GADDAGs available for a language seems to be a large speed win. These two patches together open up for larger word lists, and thus GADDAGs for more languages, like Polish and Norwegian. Only lightly tested (I don't know Polish!), but seems to work well for me.