### PR TITLE
Various microoptimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,3 +76,6 @@ add_library(libquackle
 )
 
 target_link_libraries(libquackle Threads::Threads)
+if(WIN32)
+	target_link_libraries(libquackle ws2_32)
+endif()

--- a/alphabetparameters.cpp
+++ b/alphabetparameters.cpp
@@ -39,7 +39,20 @@ LetterString String::left(const LetterString &letterString, int number)
 LetterString String::alphabetize(const LetterString &letterString)
 {
 	LetterString ret = letterString;
-	sort(ret.begin(), ret.end());
+
+	// Insertion sort; faster than calling the full complexities of
+	// std::sort for short, already nearly-sorted strings.
+	char *ptr = ret.begin();
+	for (unsigned int j = 1; j < ret.size(); ++j) {
+		Letter key = ptr[j];
+		int i = j - 1;
+		while (i >= 0 && ptr[i] > key) {
+			ptr[i + 1] = ptr[i];
+			--i;
+		}
+		ptr[i + 1] = key;
+	}
+
 	return ret;
 }
 

--- a/alphabetparameters.h
+++ b/alphabetparameters.h
@@ -71,6 +71,9 @@ LetterString setBlankness(const LetterString &letterString);
 // turns string like .ANELINn into .ANELIN?
 LetterString usedTiles(const LetterString &letterString);
 
+// A more efficient version of usedTiles.length().
+int numUsedTiles(const LetterString &letterString);
+
 // allocate a countsArray of size
 // QUACKLE_FIRST_LETTER + QUACKLE_MAXIMUM_ALPHABET_SIZE
 void counts(const LetterString &letterString, char *countsArray);
@@ -282,11 +285,16 @@ public:
 	string alphabetName() const;
 	void setAlphabetName(const string &name);
 
+	Letter letterForUsedMap(Letter letter) const {
+		return m_usedMap[(unsigned int)letter];
+	}
+
 	// finds a file in the alphabets data directory
 	static string findAlphabetFile(const string &alphabet);
 
 protected:
 	void updateLength();
+	void buildUsedMap();
 
 	int m_length;
 	Alphabet m_alphabet;
@@ -294,6 +302,11 @@ protected:
 	LetterLookupMap m_letterLookup;
 
 	string m_alphabetName;
+
+	// For blanks, contains QUACKLE_BLANK_MARK. For plain letters,
+	// contains the letter itself. For everything else, contains QUACKLE_NULL_MARK.
+	// Used to speed up String::usedTiles().
+	Letter m_usedMap[256];
 };
 
 inline int AlphabetParameters::length() const

--- a/catchall.cpp
+++ b/catchall.cpp
@@ -60,7 +60,7 @@ double CatchallEvaluator::equity(const GamePosition &position, const Move &move)
 	
 	else if (position.bag().size() > 0)
 	{
-		int leftInBagPlusSeven = position.bag().size() - move.usedTiles().length() + 7;
+		int leftInBagPlusSeven = position.bag().size() - move.numUsedTiles() + 7;
 		double heuristicArray[13] =
 		{
 			0.0, -8.0, 0.0, -0.5, -2.0, -3.5, -2.0,

--- a/evaluator.cpp
+++ b/evaluator.cpp
@@ -70,6 +70,18 @@ double ScorePlusLeaveEvaluator::sharedConsideration(const GamePosition &position
 	return 0;
 }
 
+static const float vcvalues[8][8] =
+{
+	{  0.0,   0.0,  -1.0,  -2.5,  -5.0,  -8.5, -13.5, -18.5},
+	{ -1.0,   0.0,   0.5,   0.0,  -1.5,  -5.0, -10.0,   0.0},
+	{ -3.5,  -1.0,   0.5,   1.5,  -1.5,  -3.0,   0.0,   0.0},
+	{ -7.0,  -3.5,  -0.5,   2.5,   0.0,   0.0,   0.0,   0.0},
+	{-10.0,  -6.5,  -3.0,   0.0,   0.0,   0.0,   0.0,   0.0},
+	{-13.5, -11.5,  -8.0,   0.0,   0.0,   0.0,   0.0,   0.0},
+	{-18.5, -16.5,   0.0,   0.0,   0.0,   0.0,   0.0,   0.0},
+	{-23.5,   0.0,   0.0,   0.0,   0.0,   0.0,   0.0,   0.0},
+};
+
 double ScorePlusLeaveEvaluator::leaveValue(const LetterString &leave) const
 {
 	LetterString alphabetized = String::alphabetize(leave);
@@ -134,18 +146,6 @@ double ScorePlusLeaveEvaluator::leaveValue(const LetterString &leave) const
 				cons++;
 		}
 	} 
-
-	const float vcvalues[8][8] =
-	{
-		{  0.0,   0.0,  -1.0,  -2.5,  -5.0,  -8.5, -13.5, -18.5},
-		{ -1.0,   0.0,   0.5,   0.0,  -1.5,  -5.0, -10.0,   0.0},
-		{ -3.5,  -1.0,   0.5,   1.5,  -1.5,  -3.0,   0.0,   0.0},
-		{ -7.0,  -3.5,  -0.5,   2.5,   0.0,   0.0,   0.0,   0.0},
-		{-10.0,  -6.5,  -3.0,   0.0,   0.0,   0.0,   0.0,   0.0},
-		{-13.5, -11.5,  -8.0,   0.0,   0.0,   0.0,   0.0,   0.0},
-		{-18.5, -16.5,   0.0,   0.0,   0.0,   0.0,   0.0,   0.0},
-		{-23.5,   0.0,   0.0,   0.0,   0.0,   0.0,   0.0,   0.0},
-	};
 
 #ifdef DEBUG_BOARD
 	UVcout << QUACKLE_ALPHABET_PARAMETERS->userVisible(leave) << " has " << vowels << " vowels, " << cons << " cons.  value of " << vcvalues[vowels][cons] << endl;

--- a/evaluator.cpp
+++ b/evaluator.cpp
@@ -86,8 +86,12 @@ double ScorePlusLeaveEvaluator::leaveValue(const LetterString &leave) const
 {
 	LetterString alphabetized = String::alphabetize(leave);
 	
-	if (QUACKLE_STRATEGY_PARAMETERS->hasSuperleaves() && QUACKLE_STRATEGY_PARAMETERS->superleave(alphabetized))
-		return QUACKLE_STRATEGY_PARAMETERS->superleave(alphabetized);
+	if (QUACKLE_STRATEGY_PARAMETERS->hasSuperleaves())
+	{
+		double value = QUACKLE_STRATEGY_PARAMETERS->superleave(alphabetized);
+		if (value)
+			return value;
+	}
 
 	double value = 0;
 

--- a/fixedstring.h
+++ b/fixedstring.h
@@ -54,6 +54,7 @@ class FixedLengthString
     bool empty() const;
     size_type size() const { return length(); }
     void clear() { m_end = m_data; }
+    void truncate(size_t length) { assert(length <= size()); m_end = m_data + length; }
     void push_back(char c);
     void pop_back();
     const char* constData() const { return m_data; }

--- a/fixedstring.h
+++ b/fixedstring.h
@@ -284,8 +284,6 @@ operator<(const Quackle::FixedLengthString &lhs, const Quackle::FixedLengthStrin
 }
 
 
-} // end namespace
-
 inline bool
 operator==(const Quackle::FixedLengthString &lhs, const Quackle::FixedLengthString& rhs)
 {
@@ -297,5 +295,21 @@ operator!=(const Quackle::FixedLengthString &lhs, const Quackle::FixedLengthStri
 {
     return (lhs.compare(rhs) != 0);
 }
+
+} // end namespace
+
+namespace std {
+
+template<>
+class hash<Quackle::FixedLengthString>
+{
+  public:
+    size_t operator() (const Quackle::FixedLengthString &str) const
+    {
+        return std::hash<std::string>() (std::string(str.begin(), str.end()));
+    }
+};
+
+}  // end namespace
 
 #endif

--- a/gaddag.h
+++ b/gaddag.h
@@ -35,27 +35,27 @@ public:
 	const GaddagNode *nextSibling() const;
 	const GaddagNode *child(Letter l) const;
 private:
-	unsigned char data[4];
+	uint32_t data;
 };
 
 inline Letter
 GaddagNode::letter() const
 {
-	return (data[3] & 0x3F /*0b00111111*/);
+	return data & 0x3F;
 }
 
 inline bool
 GaddagNode::isTerminal() const
 {
-	return (data[3] & 0x40) != 0 /*0b01000000*/;
+	return data & 0x40;
 }
 
 inline const GaddagNode *
 GaddagNode::firstChild() const
 {
-	unsigned int p = (data[0] << 16) + (data[1] << 8) + (data[2]);
+	unsigned int p = data >> 8;
 	if (p == 0) {
-		return 0;
+		return nullptr;
 	} else {
 		return this + p;
 	}
@@ -65,7 +65,7 @@ GaddagNode::firstChild() const
 inline const GaddagNode *
 GaddagNode::firstChild() const
 {
-	int p = (data[0] << 16) + (data[1] << 8) + (data[2]);
+	int p = data >> 8;
 	if (p == 0) 
 	{
 		return 0;
@@ -82,7 +82,7 @@ GaddagNode::firstChild() const
 inline const GaddagNode *
 GaddagNode::nextSibling() const
 {
-	if (data[3] & 0x80 /*0b10000000*/) {
+	if (data & 0x80) {
 		return 0;
 	} else {
 		return this + 1; // assumes packed array of siblings

--- a/game.cpp
+++ b/game.cpp
@@ -1317,7 +1317,7 @@ bool Quackle::operator<(const HistoryLocation &hl1, const HistoryLocation &hl2)
 	return hl1.playerId() < hl2.playerId();
 }
 
-bool operator==(const Quackle::HistoryLocation &hl1, const Quackle::HistoryLocation &hl2)
+bool Quackle::operator==(const Quackle::HistoryLocation &hl1, const Quackle::HistoryLocation &hl2)
 {
 	return hl1.turnNumber() == hl2.turnNumber() && hl1.playerId() == hl2.playerId();
 }

--- a/game.h
+++ b/game.h
@@ -914,9 +914,9 @@ inline void Game::setTitle(const UVString &title)
 	m_title = title;
 }
 
-}
-
 bool operator==(const Quackle::HistoryLocation &hl1, const Quackle::HistoryLocation &hl2);
+
+}
 
 UVOStream& operator<<(UVOStream& o, const Quackle::GamePosition &position);
 UVOStream& operator<<(UVOStream& o, const Quackle::PositionList &positions);

--- a/generator.cpp
+++ b/generator.cpp
@@ -18,6 +18,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <set>
 #include <math.h>
 
 #include "datamanager.h"
@@ -1600,7 +1601,7 @@ void Generator::wordspit(int i, const LetterString &prefix, int flags)
 
 Move Generator::exchange()
 {
-	map<LetterString, bool> throwmap;
+	set<LetterString> throwmap;
 
 	const int rackSize = rack().tiles().length();
 	const int permutations = 1 << rackSize;
@@ -1618,15 +1619,24 @@ Move Generator::exchange()
 		move.score = 0;
 		move.equity = equity(move);
 
-		if (throwmap.find(move.tiles()) == throwmap.end())
-		{
-			if (m_recordall)
+		if (m_recordall) {
+			if (throwmap.find(move.tiles()) == throwmap.end()) {
 				m_moveList.push_back(move);
 
-			if (MoveList::equityComparator(best, move)) 
-				best = move;
+				if (MoveList::equityComparator(best, move))
+					best = move;
 
-			throwmap[move.tiles()] = true;
+				throwmap.insert(move.tiles());
+			}
+		} else {
+			if (best.action == Move::Exchange &&
+			    best.tiles() == move.tiles()) {
+				// Avoid an assertion in MoveList::equityComparator().
+				// TODO: Remove the assert instead?
+				continue;
+			}
+			if (MoveList::equityComparator(best, move))
+				best = move;
 		}
 	}
 

--- a/lexiconparameters.h
+++ b/lexiconparameters.h
@@ -21,6 +21,8 @@
 
 #include <vector>
 
+#include <stdint.h>
+
 #include "gaddag.h"
 
 namespace Quackle
@@ -87,7 +89,7 @@ public:
 
 protected:
 	unsigned char *m_dawg;
-	unsigned char *m_gaddag;
+	uint32_t *m_gaddag;
 	string m_lexiconName;
 	LexiconInterpreter *m_interpreter;
 	char m_hash[16];

--- a/move.cpp
+++ b/move.cpp
@@ -83,6 +83,11 @@ LetterString Move::usedTiles() const
     return (m_isChallengedPhoney || action == BlindExchange) ? LetterString() : String::usedTiles(m_tiles);
 }
 
+int Move::numUsedTiles() const
+{
+    return (m_isChallengedPhoney || action == BlindExchange) ? 0 : String::numUsedTiles(m_tiles);
+}
+
 LetterString Move::wordTiles() const
 {
     LetterString word;

--- a/move.cpp
+++ b/move.cpp
@@ -24,7 +24,7 @@
 
 using namespace Quackle;
 
-bool operator==(const Move &move1, const Move &move2)
+bool Quackle::operator==(const Move &move1, const Move &move2)
 {
 	bool ret = false;
 

--- a/move.h
+++ b/move.h
@@ -218,11 +218,11 @@ inline bool Move::isAlreadyOnBoard(Letter letter)
 	return letter == QUACKLE_PLAYED_THRU_MARK;
 }
 
-}
-
 // we gotta overload so plays with diff equity 
 // are equal
 bool operator==(const Quackle::Move &move1, const Quackle::Move &move2);
+
+}
 
 UVOStream& operator<<(UVOStream& o, const Quackle::Move& m);
 UVOStream& operator<<(UVOStream& o, const Quackle::MoveList& moves);

--- a/move.h
+++ b/move.h
@@ -80,6 +80,9 @@ public:
 	// Returns an empty string if this is a challenged phoney.
 	LetterString usedTiles() const;
 
+	// A more efficient version of usedTiles().length.
+	int numUsedTiles() const;
+
 	// Returns tiles like PANELING (pretty tiles, nonblank,
 	// without playthru markings)
 	LetterString wordTiles() const;

--- a/player.h
+++ b/player.h
@@ -104,11 +104,11 @@ inline bool operator<(const Quackle::Player &player1, const Quackle::Player &pla
 	return player1.id() < player2.id();
 }
 
-}
-
 inline bool operator==(const Quackle::Player &player1, const Quackle::Player &player2)
 {
 	return player1.id() == player2.id();
+}
+
 }
 
 UVOStream &operator<<(UVOStream &o, const Quackle::Player &player);

--- a/quacker/quacker.pro
+++ b/quacker/quacker.pro
@@ -44,6 +44,7 @@ SOURCES += *.cpp
 
 win32 {
 	RC_FILE = quacker.rc
+	LIBS += -lws2_32
 }
 
 macx {

--- a/quackle.pro
+++ b/quackle.pro
@@ -6,6 +6,7 @@ QT -= gui core
 win32:!win32-g++ { # VS solutions don't like having two projects named "quackle"
   TARGET = libquackle
 }
+win32:LIBS += -lws2_32
 
 debug {
   OBJECTS_DIR = obj/debug

--- a/rack.cpp
+++ b/rack.cpp
@@ -41,39 +41,34 @@ bool Rack::unload(const LetterString &used)
 {
 	// UVcout << *this << ".unload(" << used << ")" << endl;
 
-	LetterString newtiles = m_tiles;
-	bool ret = true;
-
+	// Blank out rack spots that correspond to used tiles.
 	LetterString::const_iterator usedEnd(used.end());
 	for (LetterString::const_iterator usedIt = used.begin(); usedIt != usedEnd; ++usedIt)
 	{
-		bool found = false;
-
-		LetterString::iterator newEnd(newtiles.end());
-		for (LetterString::iterator newIt = newtiles.begin(); newIt != newEnd; ++newIt)
+		LetterString::iterator tileEnd(m_tiles.end());
+		for (LetterString::iterator tileIt = m_tiles.begin(); tileIt != tileEnd; ++tileIt)
 		{
-			if (*newIt == *usedIt)
+			if (*tileIt == *usedIt)
 			{
-				*newIt = QUACKLE_NULL_MARK;
-				found = true;
+				*tileIt = QUACKLE_NULL_MARK;
 				break;
 			}
 		}
-
-		if (!found)
-			ret = false;
 	}
 
-	// UVcout << "newtiles: " << newtiles << endl;
+	// Compress all blank spots. (GCC can do the body of this loop branch-free.)
+	LetterString::const_iterator tileEnd(m_tiles.end());
+	LetterString::iterator newTileEnd(m_tiles.begin());
+	for (LetterString::const_iterator tileIt = m_tiles.begin(); tileIt != tileEnd; ++tileIt)
+	{
+		*newTileEnd = *tileIt;
+		if (*tileIt != QUACKLE_NULL_MARK)
+			newTileEnd++;
+	}
 
-	m_tiles.clear();
-
-	LetterString::const_iterator newEnd(newtiles.end());
-	for (LetterString::const_iterator newIt = newtiles.begin(); newIt != newEnd; ++newIt)
-		if (*newIt != QUACKLE_NULL_MARK)
-			m_tiles += *newIt; 
-
-	return ret;
+	size_t expected_remaining_tiles = m_tiles.size() - used.size();
+	m_tiles.truncate(newTileEnd - m_tiles.begin());
+	return m_tiles.size() == expected_remaining_tiles;
 }
 
 void Rack::load(const LetterString &tiles)

--- a/strategyparameters.h
+++ b/strategyparameters.h
@@ -19,8 +19,9 @@
 #ifndef QUACKLE_STRATEGYPARAMETERS_H
 #define QUACKLE_STRATEGYPARAMETERS_H
 
-#include <map>
+#include <unordered_map>
 #include "alphabetparameters.h"
+#include "fixedstring.h"
 
 namespace Quackle
 {
@@ -60,7 +61,7 @@ protected:
 	static const int m_bogowinArrayWidth = 601;
 	static const int m_bogowinArrayHeight = 94;
 	double m_bogowin[m_bogowinArrayWidth][m_bogowinArrayHeight];
-	typedef map<LetterString, double> SuperLeavesMap;
+	typedef unordered_map<LetterString, double> SuperLeavesMap;
 	SuperLeavesMap m_superleaves;
 	bool m_hasSyn2;
 	bool m_hasWorths;


### PR DESCRIPTION
This is a collection of microoptimizations that mostly touch low-hanging fruit _outside_ the move generator (I assumed that it is hard to improve markedly on). They are presented as one patch series, but are generally independent, and you can pick out whatever you'd like from it and throw the rest away.

I couldn't immediately find an obvious benchmark to run, so all tests have been made on a (fairly open) Norwegian board that I had running, asking the Championship Player for analysis in the same situation. (In particular, this means I haven't benchmarked anything related to superleaves or synergies.) That call was then timed, repeated enough times to be fairly certain that it's a win, confirming with profiles.

The variance is fairly high, but in total, this patch series seems to gain about 15% speedup as a whole. I've only tested on GCC 10.1 (as noted in several of the patches), but I've stayed away from non-portable tricks (including SIMD code, even though it would make sense in some cases), and I'm reasonably sure that both MSVC and Clang should be happy with the changes, too. The only thing I'm unsure of is the availability of ntohl() on Windows; there might be a need to link to ws2_32 or similar, but I haven't checked.